### PR TITLE
change protocol to https for font

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <link href="http://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
     <link href="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.98.0/css/materialize.min.css" rel="stylesheet">
     <meta charset='utf-8'>
     <meta name='viewport' content='width=device-width initial-scale=1.0'>


### PR DESCRIPTION
possible fix for google oauth on heroku deployment site
changes protocol for font script reference in index.html to HTTPS from HTTP